### PR TITLE
Allow passing extra options to the request module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ var handleResponse = function( response, callback ) {
 
 var processFile = function( url, options, stream, callback ) {
 
-	var req = request.put( url );
+	var req = request.put( url , options );
 	if ( options.username && options.password ) {
 		req.auth(options.username, options.password, true);
 	}


### PR DESCRIPTION
Hi, here is a little patch to allow passing extra options to the NPM request module.
I had to patch this because when trying to uploading to a local Artifactory over an SSL connection, you may have the UNABLE_TO_VERIFY_LEAF_SIGNATURE error. To bypass this issue you have to tell the request package not to reject the certificate like so rejectUnauthorized: false ; Hence this patch.
